### PR TITLE
support transcoding webp image format via libwebp

### DIFF
--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -541,7 +541,7 @@ if command_exists "python3"; then
 fi
 
 if build "opencore" "0.1.6"; then
-  download "https://cfhcable.dl.sourceforge.net/project/opencore-amr/opencore-amr/opencore-amr-0.1.6.tar.gz"
+  download "https://sourceforge.net/projects/opencore-amr/files/opencore-amr/opencore-amr-0.1.6.tar.gz/download?use_mirror=gigenet" "opencore-amr-0.1.6.tar.gz"
   execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static
   execute make -j $MJOBS
   execute make install

--- a/build-ffmpeg
+++ b/build-ffmpeg
@@ -623,6 +623,20 @@ if $NONFREE_AND_GPL; then
 fi
 
 ##
+## Image Codecs
+##
+
+if build "libwebp" "1.6.0"; then
+  download "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.6.0.tar.gz"
+  execute ./configure --prefix="${WORKSPACE}" --disable-shared --enable-static --enable-libwebpmux --enable-libwebpdemux
+  execute make -j $MJOBS
+  execute make install
+  
+  build_done "libwebp" "1.6.0"
+fi
+CONFIGURE_OPTIONS+=("--enable-libwebp")
+
+##
 ## FFmpeg
 ##
 


### PR DESCRIPTION
In order to support transcoding webp image formats (a valid and performant image format), we need to update our ffmpeg installation in our vault transcoder to support webp. We do this by installing [the `libwebp` library](https://chromium.googlesource.com/webm/libwebp) and adding that to the ffmpeg configuration.

I also had to update the download url for `opencore-amr` ([ref](https://sourceforge.net/projects/opencore-amr/)) as the old one cannot be found. 

Ref https://linear.app/sound/issue/VLT-1131/fix-issue-with-transcoder-failing-to-handle-webp-image-filetype